### PR TITLE
add use_node_features option to spherical message passing

### DIFF
--- a/benchmarks/threedgraph/threedgraph.ipynb
+++ b/benchmarks/threedgraph/threedgraph.ipynb
@@ -116,7 +116,7 @@
     "        hidden_channels=128, out_channels=1, int_emb_size=64, \n",
     "        basis_emb_size_dist=8, basis_emb_size_angle=8, basis_emb_size_torsion=8, out_emb_channels=256, \n",
     "        num_spherical=7, num_radial=6, envelope_exponent=5, \n",
-    "        num_before_skip=1, num_after_skip=2, num_output_layers=3 \n",
+    "        num_before_skip=1, num_after_skip=2, num_output_layers=3, use_node_features=True\n",
     "        )\n",
     "loss_func = torch.nn.L1Loss()\n",
     "evaluation = ThreeDEvaluator()"


### PR DESCRIPTION
add use_node_features option to spherical message passing as discussed with @limei0307. It can be switched off to use a learned node embedding as node features instead of the one-hot encoded atomic numbers, which means that no inputs besides the 3D information are used by setting use_node_features=False.

The learned vector is initialized as standard normal.