### PR TITLE
Patch 1

### DIFF
--- a/dig/threedgraph/method/comenet/comenet.py
+++ b/dig/threedgraph/method/comenet/comenet.py
@@ -1,6 +1,6 @@
 from torch_cluster import radius_graph
 from torch_geometric.nn import GraphConv, GraphNorm
-from torch_geometric.nn.acts import swish
+from torch_geometric.nn.resolver import swish
 from torch_geometric.nn import inits
 
 from .features import angle_emb, torsion_emb

--- a/dig/threedgraph/method/dimenetpp/dimenetpp.py
+++ b/dig/threedgraph/method/dimenetpp/dimenetpp.py
@@ -1,7 +1,7 @@
 import torch
 from torch import nn
 from torch.nn import Linear, Embedding
-from torch_geometric.nn.acts import swish
+from torch_geometric.nn.resolver import swish
 from torch_geometric.nn.inits import glorot_orthogonal
 from torch_geometric.nn import radius_graph
 from torch_scatter import scatter

--- a/dig/threedgraph/method/pronet/pronet.py
+++ b/dig/threedgraph/method/pronet/pronet.py
@@ -3,7 +3,7 @@ This is an implementation of ProNet model
 
 """
 
-from torch_geometric.nn.acts import swish
+from torch_geometric.nn.resolver import swish
 from torch_geometric.nn import inits, MessagePassing
 from torch_geometric.nn import radius_graph
 

--- a/dig/threedgraph/method/spherenet/spherenet.py
+++ b/dig/threedgraph/method/spherenet/spherenet.py
@@ -1,7 +1,7 @@
 import torch
 from torch import nn
 from torch.nn import Linear, Embedding
-from torch_geometric.nn.acts import swish
+from torch_geometric.nn.resolver import swish
 from torch_geometric.nn.inits import glorot_orthogonal
 from torch_geometric.nn import radius_graph
 from torch_scatter import scatter


### PR DESCRIPTION
Hello
I don't know about the past, but currently, we don't have a module named `torch_geometric.nn.acts` and this lack has caused some problems including Issues number #156 and #115.
Above all, the code example posted on the page "Tutorial for 3D Graphs" from the DIG documentation website, doesn't work because of this problem.
According to PyG's documentation, maybe the best alternative way to access the "swish" act function is to use `from torch_geometric.nn.resolver import swish` 
thank you. 