### PR TITLE
Fix bugs in `Tutorial for GNN Explainability`

### DIFF
--- a/docs/source/tutorials/subgraphx.rst
+++ b/docs/source/tutorials/subgraphx.rst
@@ -131,8 +131,7 @@ After MCTS searching and Shapley value computation, the subgraph with the highes
     result = find_closest_node_result(explanation_results[prediction], max_nodes=max_nodes)
 
     plotutils = PlotUtils(dataset_name='ba_shapes')
-    explainer.visualization(explanation_results,
-                            prediction,
+    explainer.visualization(explanation_results[prediction],
                             max_nodes=max_nodes,
                             plot_utils=plotutils,
                             y=data.y)

--- a/docs/source/tutorials/subgraphx.rst
+++ b/docs/source/tutorials/subgraphx.rst
@@ -82,6 +82,7 @@ Since the graph model is a two-layer GNN model, the information only aggregates 
     from dig.xgraph.method.subgraphx import PlotUtils
     from dig.xgraph.method.subgraphx import MCTS
     from torch_geometric.utils import to_networkx
+    from torch_geometric.data import Data
 
     subgraph_x, subgraph_edge_index, subset, edge_mask, kwargs = \
         MCTS.__subgraph__(node_idx, data.x, data.edge_index, num_hops=2)


### PR DESCRIPTION
Add a missing import of Data [(Line 91 of the old verion)](https://github.com/divelab/DIG/pull/187/files#diff-afcd12948ee72f98c561e4c9cebfcd10f53def8ea4e819379cfb5fb4f38f3ed1L91).
Fix a wrong argument passing. Due to [changes of the API `SubgraphX.visualization`](https://github.com/divelab/DIG/compare/0.1.1...1.0.0#diff-9a2c3ea2c6101a4635b59c7ee5cca251b80697b71752290f6d2ca3644335b0f6L604), `SubgraphX.visualization` will not accept two arguments to determine the replanation results.